### PR TITLE
Replaced set-output with GITHUB_OUTPUT

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -759,14 +759,14 @@ if "%GITHUB_WORKFLOW%" neq "" (
   echo Creating %OUTPUT%.zip
   %SZIP% a -y -r -mx=9 "-x^!build" SDL3-!OUTPUT_DATE!.zip SDL3 || exit /b 1
 
-  echo ::set-output name=OUTPUT_DATE::!OUTPUT_DATE!
+  >> %GITHUB_OUTPUT% echo OUTPUT_DATE=!OUTPUT_DATE!
 
-  echo ::set-output name=SDL_COMMIT::%SDL_COMMIT%
-  echo ::set-output name=SDL_IMAGE_COMMIT::%SDL_IMAGE_COMMIT%
-  echo ::set-output name=SDL_MIXER_COMMIT::%SDL_MIXER_COMMIT%
-  echo ::set-output name=SDL_TTF_COMMIT::%SDL_TTF_COMMIT%
-  echo ::set-output name=SDL_RTF_COMMIT::%SDL_RTF_COMMIT%
-  echo ::set-output name=SDL_NET_COMMIT::%SDL_NET_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_COMMIT=%SDL_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_IMAGE_COMMIT=%SDL_IMAGE_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_MIXER_COMMIT=%SDL_MIXER_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_TTF_COMMIT=%SDL_TTF_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_RTF_COMMIT=%SDL_RTF_COMMIT%
+  >> %GITHUB_OUTPUT% echo SDL_NET_COMMIT=%SDL_NET_COMMIT%
 )
 
 rem


### PR DESCRIPTION
`set-output` seems primed for deprecation [as documented here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). The page instructs us to replace it with shell redirection.

The redirection syntax is inverted (redirection coming before `echo`) to prevent a spurious space being output by the conventional command.

There would still be deprecation warnings in the build logs, since `actions/create-release@v1` and `actions/upload-release-asset@v1`  still use `set-output`, but at least our script is free of this warning.